### PR TITLE
Install dependencies in Docker by setup.py #39927

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM ninech/netbox
 
-ENV NETBOX_GRAPHQL_PATH /opt/netbox-graphql
-ENV NETBOX_PATH /opt/netbox/netbox
-
-COPY . ${NETBOX_GRAPHQL_PATH}
-RUN pip install -e ${NETBOX_GRAPHQL_PATH}
+COPY . /opt/netbox-graphql
+RUN pip install -e /opt/netbox-graphql
 
 COPY docker /tmp/
-RUN cat /tmp/settings.py >> ${NETBOX_PATH}/netbox/settings.py && \
-    cat /tmp/urls.py >> ${NETBOX_PATH}/netbox/urls.py && \
-    ln -s ${NETBOX_GRAPHQL_PATH}/netbox-graphql ${NETBOX_PATH}/netbox-graphql
+RUN cat /tmp/settings.py >> /opt/netbox/netbox/netbox/settings.py && \
+    cat /tmp/urls.py >> /opt/netbox/netbox/netbox/urls.py && \
+    ln -s /opt/netbox-graphql/netbox-graphql /opt/netbox/netbox/netbox-graphql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ninech/netbox
 
-RUN ["pip", "install", "graphene-django==1.3", "graphene==1.4", "graphql-core==1.1", "snapshottest", "pytest"]
+ENV NETBOX_GRAPHQL_PATH /opt/netbox-graphql
+ENV NETBOX_PATH /opt/netbox/netbox
+
+COPY . ${NETBOX_GRAPHQL_PATH}
+RUN pip install -e ${NETBOX_GRAPHQL_PATH}
 
 COPY docker /tmp/
-
-RUN cat /tmp/settings.py >> /opt/netbox/netbox/netbox/settings.py
-RUN cat /tmp/urls.py >> /opt/netbox/netbox/netbox/urls.py
-
-COPY netbox-graphql /opt/netbox/netbox/netbox-graphql
-
+RUN cat /tmp/settings.py >> ${NETBOX_PATH}/netbox/settings.py && \
+    cat /tmp/urls.py >> ${NETBOX_PATH}/netbox/urls.py && \
+    ln -s ${NETBOX_GRAPHQL_PATH}/netbox-graphql ${NETBOX_PATH}/netbox-graphql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ninech/netbox
 
 COPY . /opt/netbox-graphql
-RUN pip install -e /opt/netbox-graphql
+RUN pip install /opt/netbox-graphql[test]
 
 COPY docker /tmp/
 RUN cat /tmp/settings.py >> /opt/netbox/netbox/netbox/settings.py && \

--- a/README.rst
+++ b/README.rst
@@ -150,14 +150,9 @@ The simplest way to make package and deploy it is with using `twine`::
 
 Tests
 -----
-Run unit tests::
-
-    docker-compose up -d postgres
-    
-    # wait until the database started.
-
-    docker-compose run --rm --entrypoint './manage.py' netbox test # runs all tests
-    docker-compose run --rm --entrypoint './manage.py' netbox test netbox-graphql/ # runs only netbox-graphql module tests
+Run unit tests::    
+    docker-compose run netbox ./manage.py test # runs all tests
+    docker-compose run netbox ./manage.py test netbox-graphql/ # runs only netbox-graphql module tests
 
     # At the end, you can stop any running service and cleanup as follows:
     docker-compose down

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,11 @@ setup(
         'graphene-django==1.3',
         'graphene==1.4',
         'graphql-core==1.1',
-        'snapshottest',
-        'pytest'
     ],
+    extras_require={
+        'test': [
+            'snapshottest',
+            'pytest',
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,10 @@ setup(
     ],
     keywords='django netbox graphql python',
     install_requires=[
-        'django>=1.11',
-        'graphene-django>=1.0',
-        'django-filter>=1.0.2',
-      ],
+        'graphene-django==1.3',
+        'graphene==1.4',
+        'graphql-core==1.1',
+        'snapshottest',
+        'pytest'
+    ],
 )


### PR DESCRIPTION
To be able to do this we need to copy the app beside netbox and just link the netbox-graphql folder afterwards. At least this seemed the best way to me.